### PR TITLE
Add React UI prototype for Nidus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Nidus UI Prototype
+
+This repository contains a React-based prototype for the Nidus defense-tech platform. It demonstrates an animated UI flow from mission input to asset recommendations and a forge print queue.
+
+## Development
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Start the development server
+
+```bash
+npm start
+```
+
+## Project Structure
+
+- `src/` – React source code
+- `components/` – UI components for each phase of the flow
+- `tailwind.config.js` – Tailwind CSS configuration
+
+The prototype uses Tailwind CSS, Framer Motion, and React Three Fiber.

--- a/nidus
+++ b/nidus
@@ -1,7 +1,0 @@
-echo "# nd" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/jcsullivan216/nd.git
-git push -u origin main

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "nidus-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "framer-motion": "^10.12.16",
+    "@react-three/fiber": "^8.13.5",
+    "three": "^0.154.0",
+    "@headlessui/react": "^1.7.14"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+  ],
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nidus Prototype</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import ChatPanel from './components/ChatPanel';
+import AssetRecommendations from './components/AssetRecommendations';
+import ForgeQueueTable from './components/ForgeQueueTable';
+import { AnimatePresence, motion } from 'framer-motion';
+
+const phases = {
+  CHAT: 'chat',
+  ASSETS: 'assets',
+  QUEUE: 'queue',
+};
+
+export default function App() {
+  const [phase, setPhase] = useState(phases.CHAT);
+  const [queuedAssets, setQueuedAssets] = useState([]);
+
+  const handleQueue = (asset) => {
+    setQueuedAssets([...queuedAssets, { ...asset, stage: 'Queued' }]);
+    setPhase(phases.QUEUE);
+  };
+
+  return (
+    <div className="min-h-screen p-4">
+      <AnimatePresence mode="wait">
+        {phase === phases.CHAT && (
+          <motion.div key="chat" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+            <ChatPanel onComplete={() => setPhase(phases.ASSETS)} />
+          </motion.div>
+        )}
+        {phase === phases.ASSETS && (
+          <motion.div key="assets" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+            <AssetRecommendations onQueue={handleQueue} />
+          </motion.div>
+        )}
+        {phase === phases.QUEUE && (
+          <motion.div key="queue" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+            <ForgeQueueTable assets={queuedAssets} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/AssetCard.js
+++ b/src/components/AssetCard.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+import { motion } from 'framer-motion';
+
+function Box() {
+  return (
+    <mesh rotation={[45,45,0]}>
+      <boxGeometry args={[1,1,1]} />
+      <meshStandardMaterial color="#4ade80"/>
+    </mesh>
+  );
+}
+
+export default function AssetCard({ asset, onQueue }) {
+  return (
+    <motion.div whileHover={{ scale: 1.02 }} className="bg-primary rounded-md p-4 shadow-md flex flex-col">
+      <div className="h-40 w-full">
+        <Canvas camera={{ position: [2,2,2] }}>
+          <ambientLight />
+          <pointLight position={[10,10,10]} />
+          <Box />
+        </Canvas>
+      </div>
+      <h3 className="text-lg font-semibold mt-2">{asset.name}</h3>
+      <ul className="text-sm flex-1 mt-2 space-y-1">
+        <li>Mobility: {asset.mobility}</li>
+        <li>Sensors: {asset.sensors}</li>
+        <li>Duration: {asset.duration}</li>
+        <li>Comms: {asset.comms}</li>
+        <li>Time to Print: {asset.printTime}</li>
+        <li>Forge Draw: {asset.resources}</li>
+      </ul>
+      <button onClick={() => onQueue(asset)} className="bg-accent text-black mt-4 py-1 rounded">Queue to Print</button>
+    </motion.div>
+  );
+}

--- a/src/components/AssetRecommendations.js
+++ b/src/components/AssetRecommendations.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import AssetCard from './AssetCard';
+import { motion } from 'framer-motion';
+
+const mockAssets = [
+  {
+    name: 'Scout Drone',
+    mobility: 'Rotor',
+    sensors: 'EO/IR Camera',
+    duration: '45 min',
+    comms: 'Mesh Link',
+    printTime: '4.5 hrs',
+    resources: '2.1kg filament, 250W',
+  },
+  {
+    name: 'UGV Rover',
+    mobility: 'Wheeled',
+    sensors: 'Lidar + Camera',
+    duration: '3 hr',
+    comms: 'Secure Radio',
+    printTime: '6 hrs',
+    resources: '3kg filament, 400W',
+  },
+];
+
+export default function AssetRecommendations({ onQueue }) {
+  return (
+    <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-4">
+      {mockAssets.map((asset) => (
+        <motion.div key={asset.name} initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+          <AssetCard asset={asset} onQueue={onQueue} />
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ChatPanel.js
+++ b/src/components/ChatPanel.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+
+export default function ChatPanel({ onComplete }) {
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState([
+    { sender: 'system', text: 'How can I assist your mission?' }
+  ]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSend = () => {
+    if (!input) return;
+    setMessages([...messages, { sender: 'user', text: input }]);
+    setInput('');
+    setLoading(true);
+    setTimeout(() => {
+      setMessages((prev) => [
+        ...prev,
+        { sender: 'system', text: 'What domain is the asset operating in?' },
+        { sender: 'system', text: 'Any time constraints or threat profile?' }
+      ]);
+      setLoading(false);
+      onComplete();
+    }, 1000);
+  };
+
+  return (
+    <div className="max-w-xl mx-auto bg-primary p-4 rounded-md shadow-md">
+      <div className="space-y-2 h-64 overflow-y-auto mb-4">
+        {messages.map((msg, idx) => (
+          <div key={idx} className={`text-sm ${msg.sender === 'user' ? 'text-right' : ''}`}>
+            <span className="block px-2 py-1 rounded bg-gray-700 inline-block">
+              {msg.text}
+            </span>
+          </div>
+        ))}
+        {loading && (
+          <motion.div animate={{ opacity: [0,1,0] }} transition={{ repeat: Infinity, duration: 1 }} className="text-gray-400 text-sm">
+            thinking...
+          </motion.div>
+        )}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 bg-gray-800 rounded px-2 py-1 focus:outline-none"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Enter mission details"/>
+        <button className="bg-accent text-black px-3 py-1 rounded" onClick={handleSend}>Send</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ForgeQueueTable.js
+++ b/src/components/ForgeQueueTable.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+
+export default function ForgeQueueTable({ assets }) {
+  const [rows, setRows] = useState([]);
+
+  useEffect(() => {
+    setRows(assets.map(a => ({ ...a, time: a.printTime, stage: 'Queued' })));
+  }, [assets]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRows((rs) => rs.map(r => {
+        if (r.stage === 'Queued') return { ...r, stage: 'In Progress' };
+        if (r.stage === 'In Progress') return { ...r, stage: 'Cooling' };
+        if (r.stage === 'Cooling') return { ...r, stage: 'Ready' };
+        return r;
+      }));
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h2 className="text-xl mb-2">Forge Queue</h2>
+      <table className="w-full text-sm bg-primary rounded-md overflow-hidden">
+        <thead className="bg-gray-700">
+          <tr>
+            <th className="p-2 text-left">Asset Name</th>
+            <th className="p-2">Time Left</th>
+            <th className="p-2">Stage</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, idx) => (
+            <motion.tr key={idx} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="border-b border-gray-700">
+              <td className="p-2">{r.name}</td>
+              <td className="p-2 text-center">{r.time}</td>
+              <td className="p-2 text-center">
+                {r.stage === 'In Progress' && <motion.span animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 2 }} className="inline-block">🔄</motion.span>}
+                {r.stage}
+              </td>
+            </motion.tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-background text-gray-200 font-sans;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0f0f11',
+        primary: '#1f2937',
+        accent: '#4ade80',
+      }
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- create React project scaffolding with Tailwind CSS, Framer Motion, and Three.js
- implement ChatPanel, AssetRecommendations (with AssetCard), and ForgeQueueTable
- wire components together in App.js for three‑phase animated flow
- add Tailwind and PostCSS configuration
- document setup instructions in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e2612990832c86bcd0ad365218bd